### PR TITLE
Add support for lowercase input

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/WhatTheErrorCode.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/WhatTheErrorCode.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1420"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WhatTheErrorCode"
+               BuildableName = "WhatTheErrorCode"
+               BlueprintName = "WhatTheErrorCode"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WhatTheErrorCodeTests"
+               BuildableName = "WhatTheErrorCodeTests"
+               BlueprintName = "WhatTheErrorCodeTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WhatTheErrorCode"
+            BuildableName = "WhatTheErrorCode"
+            BlueprintName = "WhatTheErrorCode"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Sources/WhatTheErrorCode/WhatTheErrorCode.swift
+++ b/Sources/WhatTheErrorCode/WhatTheErrorCode.swift
@@ -37,7 +37,7 @@ public struct WhatTheErrorCode {
 
 extension [CocoaErrorDomain] {
     func error(for input: WhatTheErrorCodeInput) -> CocoaErrorDescription? {
-        first(where: { $0.key == input.domain })?
+        first(where: { $0.key.lowercased() == input.domain.lowercased() })?
             .errors
             .first(where: { $0.code == input.code })
     }

--- a/Sources/WhatTheErrorCode/WhatTheErrorCodeInputFactory.swift
+++ b/Sources/WhatTheErrorCode/WhatTheErrorCodeInputFactory.swift
@@ -16,11 +16,11 @@ struct WhatTheErrorCodeInputFactory {
     let rawValue: String
 
     func make() -> WhatTheErrorCodeInput? {
-        let pattern = #"Domain=([^\s]+).*Code=(-?\d+)"#
+        let rawValue = rawValue.lowercased()
+        let pattern = #"domain=([^\s]+).*code=(-?\d+)"#
         let regex = try! NSRegularExpression(pattern: pattern)
-        let nsInput = rawValue as NSString
 
-        guard let result = regex.firstMatch(in: rawValue, options: [], range: NSRange(location: 0, length: nsInput.length)) else { return nil }
+        guard let result = regex.firstMatch(in: rawValue, options: [], range: NSRange(location: 0, length: rawValue.count)) else { return nil }
 
         guard
             let domainRange = Range(result.range(at: 1), in: rawValue),

--- a/Tests/WhatTheErrorCodeTests/WhatTheErrorCodeTests.swift
+++ b/Tests/WhatTheErrorCodeTests/WhatTheErrorCodeTests.swift
@@ -14,6 +14,18 @@ final class WhatTheErrorCodeTests: XCTestCase {
         )
     }
 
+    func testLowercaseExample() throws {
+        let expectedError = CocoaErrorDescription(
+            code: 1590,
+            key: "NSValidationRelationshipExceedsMaximumCountError",
+            description: "bounded, to-many relationship with too many destination objects"
+        )
+        XCTAssertEqual(
+            WhatTheErrorCode.description(for: "domain=nscocoaerrordomain code=1590 \"The operation couldn't be completed. (Cocoa error 1590.)"),
+            expectedError
+        )
+    }
+
     func testNSURLErrorDomainExample() throws {
         let expectedError = CocoaErrorDescription(
             code: -1020,


### PR DESCRIPTION
This now also works:

"domain=nscocoaerrordomain code=1590 \"The operation couldn't be completed. (Cocoa error 1590.)"