### PR TITLE
Single Error inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ And you have no clue what the code means? Use this app to find a description:
 ## Supported error domains
 - [x] `NSCocoaErrorDomain`
 - [x] `NSURLErrorDomain`
+- [ ] `kCFErrorDomainCFNetwork`
 
 ## Can I help contribute?
 Yes, please! Feel free to open a PR and add new error descriptions to [this JSON file](Sources/WhatTheErrorCode/errors.json).

--- a/Sources/WhatTheErrorCode/WhatTheErrorCode.swift
+++ b/Sources/WhatTheErrorCode/WhatTheErrorCode.swift
@@ -37,8 +37,13 @@ public struct WhatTheErrorCode {
 
 extension [CocoaErrorDomain] {
     func error(for input: WhatTheErrorCodeInput) -> CocoaErrorDescription? {
-        first(where: { $0.key.lowercased() == input.domain.lowercased() })?
-            .errors
-            .first(where: { $0.code == input.code })
+        if let domain = input.domain {
+            return first(where: { $0.key.lowercased() == domain.lowercased() })?
+                .errors
+                .first(where: { $0.code == input.code })
+        } else {
+            return flatMap(\.errors)
+                .first(where: { $0.code == input.code })
+        }
     }
 }

--- a/Sources/WhatTheErrorCode/WhatTheErrorCode.swift
+++ b/Sources/WhatTheErrorCode/WhatTheErrorCode.swift
@@ -25,25 +25,25 @@ public struct WhatTheErrorCode {
         return errorDomains
     }()
 
-    public static func description(for input: String) -> CocoaErrorDescription? {
+    public static func description(for input: String) -> [CocoaErrorDescription] {
         guard let input = WhatTheErrorCodeInputFactory(rawValue: input).make() else {
-            return nil
+            return []
         }
         print("Input is \(input)")
 
-        return errorDomains.error(for: input)
+        return errorDomains.errors(for: input)
     }
 }
 
 extension [CocoaErrorDomain] {
-    func error(for input: WhatTheErrorCodeInput) -> CocoaErrorDescription? {
+    func errors(for input: WhatTheErrorCodeInput) -> [CocoaErrorDescription] {
         if let domain = input.domain {
             return first(where: { $0.key.lowercased() == domain.lowercased() })?
                 .errors
-                .first(where: { $0.code == input.code })
+                .filter { $0.code == input.code } ?? []
         } else {
             return flatMap(\.errors)
-                .first(where: { $0.code == input.code })
+                .filter { $0.code == input.code }
         }
     }
 }

--- a/Sources/WhatTheErrorCode/WhatTheErrorCodeInputView.swift
+++ b/Sources/WhatTheErrorCode/WhatTheErrorCodeInputView.swift
@@ -55,10 +55,6 @@ public struct WhatTheErrorCodeInputView: View {
     }
 
     private func updateResult() {
-        guard let error = WhatTheErrorCode.description(for: input) else {
-            result.removeAll()
-            return
-        }
-        result = [error]
+        result = WhatTheErrorCode.description(for: input)
     }
 }

--- a/Tests/WhatTheErrorCodeTests/WhatTheErrorCodeTests.swift
+++ b/Tests/WhatTheErrorCodeTests/WhatTheErrorCodeTests.swift
@@ -10,7 +10,7 @@ final class WhatTheErrorCodeTests: XCTestCase {
         )
         XCTAssertEqual(
             WhatTheErrorCode.description(for: "code=1590"),
-            expectedError
+            [expectedError]
         )
     }
 
@@ -22,7 +22,7 @@ final class WhatTheErrorCodeTests: XCTestCase {
         )
         XCTAssertEqual(
             WhatTheErrorCode.description(for: "1590"),
-            expectedError
+            [expectedError]
         )
     }
 
@@ -34,7 +34,7 @@ final class WhatTheErrorCodeTests: XCTestCase {
         )
         XCTAssertEqual(
             WhatTheErrorCode.description(for: "Domain=NSCocoaErrorDomain Code=1590 \"The operation couldn't be completed. (Cocoa error 1590.)"),
-            expectedError
+            [expectedError]
         )
     }
 
@@ -46,7 +46,7 @@ final class WhatTheErrorCodeTests: XCTestCase {
         )
         XCTAssertEqual(
             WhatTheErrorCode.description(for: "domain=nscocoaerrordomain code=1590 \"The operation couldn't be completed. (Cocoa error 1590.)"),
-            expectedError
+            [expectedError]
         )
     }
 
@@ -60,7 +60,7 @@ final class WhatTheErrorCodeTests: XCTestCase {
             WhatTheErrorCode.description(for: """
             Error Domain=NSURLErrorDomain Code=-1020 "De momento, não é permitida a transmissão de dados." UserInfo={_kCFStreamErrorCodeKey=50
             """),
-            expectedError
+            [expectedError]
         )
     }
 

--- a/Tests/WhatTheErrorCodeTests/WhatTheErrorCodeTests.swift
+++ b/Tests/WhatTheErrorCodeTests/WhatTheErrorCodeTests.swift
@@ -2,6 +2,30 @@ import XCTest
 @testable import WhatTheErrorCode
 
 final class WhatTheErrorCodeTests: XCTestCase {
+    func testCodeWithKeyOnlyInput() throws {
+        let expectedError = CocoaErrorDescription(
+            code: 1590,
+            key: "NSValidationRelationshipExceedsMaximumCountError",
+            description: "bounded, to-many relationship with too many destination objects"
+        )
+        XCTAssertEqual(
+            WhatTheErrorCode.description(for: "code=1590"),
+            expectedError
+        )
+    }
+
+    func testCodeOnlyInput() throws {
+        let expectedError = CocoaErrorDescription(
+            code: 1590,
+            key: "NSValidationRelationshipExceedsMaximumCountError",
+            description: "bounded, to-many relationship with too many destination objects"
+        )
+        XCTAssertEqual(
+            WhatTheErrorCode.description(for: "1590"),
+            expectedError
+        )
+    }
+
     func testCoreDataExample() throws {
         let expectedError = CocoaErrorDescription(
             code: 1590,


### PR DESCRIPTION
Works with `code=-1100` and `-1100` now.