### PR TITLE
Multi-line error description and resizable columns

### DIFF
--- a/Sources/WhatTheErrorCode/WhatTheErrorCodeInputView.swift
+++ b/Sources/WhatTheErrorCode/WhatTheErrorCodeInputView.swift
@@ -46,10 +46,11 @@ public struct WhatTheErrorCodeInputView: View {
             }.width(50)
 
             TableColumn("Key", value: \.key)
-                .width(340)
+                .width(min: 100, ideal: 150)
 
             TableColumn("Description") { error in
                 Text(error.description.localizedCapitalized)
+                    .lineLimit(nil)
             }
         }
         .textSelection(.enabled)


### PR DESCRIPTION
Allows the descriptions text to go into more than one line and allows the "Key" column to be resizable. This change makes it easier to view the results on a smaller window so one doesn't have to resize the window to view the full description text.